### PR TITLE
Add JS translation of smartbot

### DIFF
--- a/Bots/risefall/12_smartbotV1.js
+++ b/Bots/risefall/12_smartbotV1.js
@@ -1,0 +1,146 @@
+// JavaScript translation of 12 smartbotV1.xml
+// This is a hand-written reconstruction of the blockly bot logic.
+// It outlines the control flow used by the bot: initialization,
+// tick analysis, trading decisions, and post-trade handling.
+
+// --- Variable definitions ---
+let Gap = 0;
+let posisi = 0;
+let expectedProfit = 0;      // set via prompt in original bot
+let Tik = 5;
+let initialAmount = 0.35;    // stake
+let Martil = 0;              // martingale level (prompt)
+let maxLossAmount = 800;
+let po = 0;
+let winAmount = 0.35;
+let aktif = 0;
+let jloss = 0;
+let closs = 0;
+let Tloss = 0;
+
+// Placeholder API ------------------------------------------------------------
+function prompt(msg) { /* user input stub */ return 0; }
+function notify(type, msg) { /* notification stub */ }
+function purchase(type) { /* place trade stub CALL/PUT */ }
+function tick() { return 0; }
+function readOHLC(field, index) { return 0; }
+function readDetails(index) { return 0; }
+function totalProfit() { return 0; }
+function tradeAgain() { /* restart trade logic */ }
+
+// --- Initialization ---
+function init() {
+  if (expectedProfit === null || expectedProfit === 0) {
+    expectedProfit = prompt('Expected Profit?');
+  }
+  if (Martil === null || Martil === 0) {
+    Martil = prompt('Martingale Level?');
+  }
+  // Set defaults for remaining variables
+  maxLossAmount = 800;
+  initialAmount = 0.35;
+  winAmount = 0.35;
+  posisi = 0;
+  Tik = 5;
+  jloss = 0;
+  aktif = 0;
+  Tloss = 0;
+  po = 0;
+  closs = 0;
+  Gap = 0;
+}
+
+// --- Strategy executed before each purchase ---
+function beforePurchase() {
+  if (posisi === 10) {
+    if (po === 0) {
+      purchase('PUT');
+    } else {
+      if (tick() < readOHLC('close', 1)) {
+        notify('warn', 'Analizing...');
+      } else if (tick() > readOHLC('close', 1)) {
+        purchase('CALL');
+      }
+    }
+  } else if (posisi === 20) {
+    if (po === 0) {
+      purchase('CALL');
+    } else {
+      if (tick() > readOHLC('close', 1)) {
+        notify('warn', 'Analizing...');
+      } else if (tick() < readOHLC('close', 1)) {
+        purchase('PUT');
+      }
+    }
+  }
+}
+
+// --- Tick analysis ---
+function tickAnalysis() {
+  if (posisi === 1) {
+    if (tick() < readOHLC('close', 1)) {
+      notify('warn', 'Analizing...');
+      if (aktif === 0) {
+        aktif = 1;
+        notify('success', 'Bot is on!');
+      }
+    } else if (tick() > readOHLC('close', 1)) {
+      // Complex gap and candle checks
+      const lowPlusGap = readOHLC('low', 1) + 1 + Gap;
+      if (tick() < lowPlusGap) {
+        posisi = 0;
+        notify('warn', 'Analizing...');
+      } else {
+        if (aktif === 0) {
+          aktif = 1;
+          notify('success', 'Bot is on!');
+        }
+        posisi = 20;
+      }
+    }
+  } else {
+    if (aktif === 0) {
+      notify('error', 'Bot is off!..');
+    }
+  }
+}
+
+// --- After purchase handling ---
+function afterPurchase(result) {
+  posisi = 0;
+  if (result === 'win') {
+    initialAmount = winAmount;
+    Tik = 5;
+    jloss = 0;
+    if (closs >= 2) {
+      po = po === 0 ? 1 : 0;
+      closs = 0;
+    }
+  } else {
+    // loss branch
+    jloss++;
+    closs++;
+    if (jloss < Martil) {
+      const loss = Math.abs(readDetails(4));
+      initialAmount += loss * 1.1;
+    } else {
+      initialAmount = winAmount;
+    }
+    Tloss = Math.abs(readDetails(4));
+    if (Tloss >= maxLossAmount) {
+      tradeAgain();
+    } else if (totalProfit() >= expectedProfit) {
+      notify('success', `Done! Total profit: ${totalProfit()}`);
+    } else if (totalProfit() < expectedProfit) {
+      tradeAgain();
+    }
+  }
+}
+
+// Exported API ---------------------------------------------------------------
+module.exports = {
+  init,
+  beforePurchase,
+  tickAnalysis,
+  afterPurchase,
+};


### PR DESCRIPTION
## Summary
- Provide a JavaScript translation of the `12 smartbotV1.xml` bot logic.
- Include initialization, tick analysis, trading decisions, and after-purchase handling in one file for easy reuse.

## Testing
- `node Bots/risefall/12_smartbotV1.js`

------
https://chatgpt.com/codex/tasks/task_e_689b78a13bc08329ad41d995993cdee3