### PR TITLE
Implement RSI strategy for 5 Best bot

### DIFF
--- a/Bots/risefall/2_3_sma.js
+++ b/Bots/risefall/2_3_sma.js
@@ -1,0 +1,122 @@
+// JavaScript translation of 2-3-sma.xml
+// Reconstructed core trading logic from the original blockly file.
+
+// ---- Variables ----
+let initialStake = 0.35;
+let stopLoss = 300;
+let targetProfit = 50;
+let martingale = 1.36;
+let stake = initialStake;
+let totalProfit = 0;
+let maxLoss = 0;
+
+let lastTick = 0;
+let tickList = [];
+
+// Placeholder API ------------------------------------------------------------
+function purchase(type) { /* CALL or PUT order */ }
+function tick() { return 0; }
+function ticks() { return []; }
+function notify(type, msg) { /* notify stub */ }
+function tradeAgain() { /* restart trade logic */ }
+function readDetails(index) { return 0; }
+
+// ---- Utility helpers ----
+function sma(list, period) {
+  if (!list || list.length < period) return 0;
+  const slice = list.slice(-period);
+  const sum = slice.reduce((a, b) => a + b, 0);
+  return sum / slice.length;
+}
+
+// ---- Configuration ----
+function config(_initialStake, _stopLoss, _targetProfit) {
+  initialStake = _initialStake;
+  stopLoss = _stopLoss;
+  targetProfit = _targetProfit;
+  stake = _initialStake;
+  totalProfit = 0;
+  maxLoss = 0;
+}
+
+// ---- Strategy helpers ----
+function stakeValue() {
+  return stake;
+}
+
+function isFromBelow() {
+  return (
+    lastTick > sma(tickList, 100) &&
+    sma(tickList, 12) > sma(tickList, 100) &&
+    sma(tickList, 4) > sma(tickList, 12)
+  );
+}
+
+function isFromAbove() {
+  return (
+    lastTick < sma(tickList, 100) &&
+    sma(tickList, 12) < sma(tickList, 100) &&
+    sma(tickList, 4) < sma(tickList, 12)
+  );
+}
+
+// ---- Life-cycle hooks ----
+function init() {
+  config(initialStake, stopLoss, targetProfit);
+}
+
+function beforePurchase() {
+  if (isFromBelow()) {
+    purchase('CALL');
+  } else if (isFromAbove()) {
+    purchase('PUT');
+  }
+}
+
+function tickAnalysis() {
+  lastTick = tick();
+  tickList = ticks();
+}
+
+function doMartingale(result, profit) {
+  totalProfit += profit;
+  if (result === 'win') {
+    stake = initialStake;
+  } else {
+    stake *= martingale;
+  }
+  if (totalProfit < maxLoss) {
+    maxLoss = totalProfit;
+  }
+}
+
+function checkStops() {
+  if (totalProfit > targetProfit) {
+    notify('success', `Win ${totalProfit}`);
+    return false;
+  }
+  if (totalProfit < -stopLoss) {
+    notify('info', `Loose ${totalProfit}`);
+    return false;
+  }
+  notify('success', `Total Profit: ${totalProfit} Max Loss: ${maxLoss}`);
+  return totalProfit < targetProfit && totalProfit > -stopLoss;
+}
+
+function afterPurchase(result) {
+  const profit = Math.abs(readDetails(4));
+  doMartingale(result, profit);
+  if (checkStops()) {
+    tradeAgain();
+  }
+}
+
+// Exported API ---------------------------------------------------------------
+module.exports = {
+  init,
+  beforePurchase,
+  tickAnalysis,
+  afterPurchase,
+  stake: stakeValue,
+};
+

--- a/Bots/risefall/5_Best_Rsi_90_10_Profit_7_diario.js
+++ b/Bots/risefall/5_Best_Rsi_90_10_Profit_7_diario.js
@@ -1,0 +1,93 @@
+// JavaScript translation of 5_Best_Rsi_90_10_Profit_7%_diario.xml
+// Reconstructed core trading logic from the original blockly file.
+
+// ---- Variables ----
+let maxAcceptableLoss = 800;
+let targetProfit = 25;
+let winAmount = 0.35;
+let initialStake = 0.35;
+let stake = initialStake;
+let totalProfit = 0;
+
+let tickList = [];
+
+// Placeholder API ------------------------------------------------------------
+function purchase(type) { /* CALL or PUT order */ }
+function ticks() { return []; }
+function notify(type, msg) { /* notification stub */ }
+function tradeAgain() { /* restart trading */ }
+function readDetails(index) { return 0; }
+
+// ---- Indicator helpers ----
+function rsi(values, period) {
+  if (!values || values.length <= period) return 0;
+  let gain = 0;
+  let loss = 0;
+  for (let i = values.length - period + 1; i < values.length; i++) {
+    const change = values[i] - values[i - 1];
+    if (change >= 0) gain += change; else loss -= change;
+  }
+  if (loss === 0) return 100;
+  const rs = gain / loss;
+  return 100 - 100 / (1 + rs);
+}
+
+function stakeValue() { return stake; }
+
+// ---- Life-cycle hooks ----
+function init() {
+  stake = initialStake;
+  totalProfit = 0;
+}
+
+function tickAnalysis() {
+  tickList = ticks();
+}
+
+function beforePurchase() {
+  const rsiValue = rsi(tickList, 2);
+  notify('error', `RSI: ${rsiValue}`);
+  if (rsiValue >= 90) {
+    purchase('PUT');
+  } else if (rsiValue <= 10) {
+    purchase('CALL');
+  }
+}
+
+function checkStops() {
+  if (totalProfit >= targetProfit) {
+    notify('info', `Done! Total profit: ${totalProfit}`);
+    return false;
+  }
+  if (totalProfit < 0 && Math.abs(totalProfit) >= maxAcceptableLoss) {
+    notify('info', 'Max Acceptable Loss Reached');
+    return false;
+  }
+  return true;
+}
+
+function afterPurchase(result) {
+  const profit = Math.abs(readDetails(4));
+  if (result === 'win') {
+    notify('success', `Won: ${profit}`);
+    stake = winAmount;
+    totalProfit += profit;
+  } else {
+    notify('warn', `Lost: ${profit}`);
+    stake += profit * 1.041;
+    totalProfit -= profit;
+  }
+  notify('info', `Total Profit: ${totalProfit}`);
+  if (checkStops()) {
+    tradeAgain();
+  }
+}
+
+// Exported API ---------------------------------------------------------------
+module.exports = {
+  init,
+  beforePurchase,
+  tickAnalysis,
+  afterPurchase,
+  stake: stakeValue,
+};

--- a/Bots/risefall/AT_bot.js
+++ b/Bots/risefall/AT_bot.js
@@ -1,0 +1,98 @@
+// JavaScript translation of AT bot.xml
+// Reconstructed with a simplified 1-3-7 martingale strategy.
+
+// --- Variables ---
+let baseStake = 1;
+let stake = baseStake;
+let level = 0;           // 0:base, 1:*3, 2:*7
+let totalProfit = 0;
+let targetProfit = 10;
+let stopLoss = 50;
+let lastClose = 0;
+
+// Placeholder API ------------------------------------------------------------
+function purchase(type) { /* CALL or PUT order */ }
+function tick() { return 0; }
+function readOHLC(field, index) { return 0; }
+function readDetails(index) { return 0; }
+function notify(type, msg) { /* notification stub */ }
+function tradeAgain() { /* restart trade logic */ }
+
+// --- Initialization ---
+function init() {
+  stake = baseStake;
+  level = 0;
+  totalProfit = 0;
+  lastClose = readOHLC('close', 1);
+}
+
+// --- Strategy helpers ---
+function stakeValue() {
+  return stake;
+}
+
+// Decide CALL or PUT based on last close vs current tick
+function beforePurchase() {
+  const current = tick();
+  if (current >= lastClose) {
+    purchase('CALL');
+  } else {
+    purchase('PUT');
+  }
+}
+
+// Update last close for next decision
+function tickAnalysis() {
+  lastClose = readOHLC('close', 1);
+}
+
+function handleMartingale(result, profit) {
+  if (result === 'win') {
+    totalProfit += profit;
+    stake = baseStake;
+    level = 0;
+  } else {
+    totalProfit -= profit;
+    if (level === 0) {
+      stake = baseStake * 3;
+      level = 1;
+    } else if (level === 1) {
+      stake = baseStake * 7;
+      level = 2;
+    } else {
+      stake = baseStake;
+      level = 0;
+    }
+  }
+}
+
+function checkStops() {
+  if (totalProfit >= targetProfit) {
+    notify('success', `Target hit: ${totalProfit}`);
+    return false;
+  }
+  if (totalProfit <= -stopLoss) {
+    notify('error', `Stop loss hit: ${totalProfit}`);
+    return false;
+  }
+  notify('info', `Total Profit: ${totalProfit}`);
+  return true;
+}
+
+// --- After purchase ---
+function afterPurchase(result) {
+  const profit = Math.abs(readDetails(4));
+  handleMartingale(result, profit);
+  if (checkStops()) {
+    tradeAgain();
+  }
+}
+
+// Exported API ---------------------------------------------------------------
+module.exports = {
+  init,
+  beforePurchase,
+  tickAnalysis,
+  afterPurchase,
+  stake: stakeValue,
+};

--- a/Bots/risefall/BB_slow_bot.js
+++ b/Bots/risefall/BB_slow_bot.js
@@ -1,0 +1,120 @@
+// JavaScript translation of BB slow bot.xml
+// Simplified Bollinger Band strategy with configurable martingale.
+
+// --- Variables ---
+let baseStake = 10;
+let stake = baseStake;
+let martingaleFactor = 2;
+let martingaleLevel = 2;
+let level = 0;
+let totalProfit = 0;
+let targetProfit = 500;
+let stopLoss = 500;
+let ticksArr = [];
+
+// Placeholder API ------------------------------------------------------------
+function purchase(type) { /* CALL or PUT order */ }
+function tick() { return 0; }
+function ticks() { return []; }
+function readDetails(index) { return 0; }
+function notify(type, msg) { /* stub */ }
+function tradeAgain() { /* restart */ }
+
+// --- Helpers ---
+function stakeValue() {
+  return stake;
+}
+
+function sma(list, period) {
+  if (list.length < period) return 0;
+  const slice = list.slice(-period);
+  const sum = slice.reduce((a, b) => a + b, 0);
+  return sum / slice.length;
+}
+
+function stdDev(list, period) {
+  if (list.length < period) return 0;
+  const avg = sma(list, period);
+  const slice = list.slice(-period);
+  const variance = slice.reduce((a, b) => a + Math.pow(b - avg, 2), 0) / slice.length;
+  return Math.sqrt(variance);
+}
+
+function bollingerBands(list, period, mult = 2) {
+  const mid = sma(list, period);
+  const sd = stdDev(list, period);
+  return {
+    upper: mid + mult * sd,
+    lower: mid - mult * sd,
+  };
+}
+
+// --- Life-cycle ---
+function init() {
+  stake = baseStake;
+  level = 0;
+  totalProfit = 0;
+  ticksArr = [];
+}
+
+function beforePurchase() {
+  if (ticksArr.length < 20) return;
+  const price = tick();
+  const bb = bollingerBands(ticksArr, 20, 2);
+  if (price > bb.upper) {
+    purchase('PUT');
+  } else if (price < bb.lower) {
+    purchase('CALL');
+  }
+}
+
+function tickAnalysis() {
+  ticksArr = ticks();
+}
+
+function handleMartingale(result, profit) {
+  if (result === 'win') {
+    totalProfit += profit;
+    stake = baseStake;
+    level = 0;
+  } else {
+    totalProfit -= profit;
+    if (level < martingaleLevel) {
+      stake *= martingaleFactor;
+      level++;
+    } else {
+      stake = baseStake;
+      level = 0;
+    }
+  }
+}
+
+function checkStops() {
+  if (totalProfit >= targetProfit) {
+    notify('success', `Target hit: ${totalProfit}`);
+    return false;
+  }
+  if (totalProfit <= -stopLoss) {
+    notify('error', `Stop loss: ${totalProfit}`);
+    return false;
+  }
+  notify('info', `Total Profit: ${totalProfit}`);
+  return true;
+}
+
+function afterPurchase(result) {
+  const profit = Math.abs(readDetails(4));
+  handleMartingale(result, profit);
+  if (checkStops()) {
+    tradeAgain();
+  }
+}
+
+// Exported API ---------------------------------------------------------------
+module.exports = {
+  init,
+  beforePurchase,
+  tickAnalysis,
+  afterPurchase,
+  stake: stakeValue,
+};

--- a/Bots/risefall/BOT_REVERSE_SIGNAL_FOX_TRADER_1.js
+++ b/Bots/risefall/BOT_REVERSE_SIGNAL_FOX_TRADER_1.js
@@ -1,0 +1,9 @@
+// JavaScript translation of BOT REVERSE SIGNAL FOX TRADER (1).xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/BOT_fssst60.js
+++ b/Bots/risefall/BOT_fssst60.js
@@ -1,0 +1,9 @@
+// JavaScript translation of BOT-fssst60.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Big_Boyz_Rise_N_fall.js
+++ b/Bots/risefall/Big_Boyz_Rise_N_fall.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Big  Boyz Rise N' fall.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Binary_CALL_PUT_Bot_Ever.js
+++ b/Bots/risefall/Binary_CALL_PUT_Bot_Ever.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Binary CALL PUT Bot Ever.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/CANDLE_SAFETY_ON_OFF_SYSTEM.js
+++ b/Bots/risefall/CANDLE_SAFETY_ON_OFF_SYSTEM.js
@@ -1,0 +1,9 @@
+// JavaScript translation of CANDLE SAFETY ON_OFF SYSTEM.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Candle_Follower_1.js
+++ b/Bots/risefall/Candle_Follower_1.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Candle Follower (1).xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Candles_Majestic_LiveBots.js
+++ b/Bots/risefall/Candles_Majestic_LiveBots.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Candles Majestic - LiveBots.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/CutlerRSI.js
+++ b/Bots/risefall/CutlerRSI.js
@@ -1,0 +1,9 @@
+// JavaScript translation of CutlerRSI.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/DBot_Candle_Cross_SMA_6_14_24_with_correction_rev1.js
+++ b/Bots/risefall/DBot_Candle_Cross_SMA_6_14_24_with_correction_rev1.js
@@ -1,0 +1,9 @@
+// JavaScript translation of DBot Candle Cross SMA-6-14-24 with correction rev1.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Daily_Reset_Spy_Bot.js
+++ b/Bots/risefall/Daily_Reset_Spy_Bot.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Daily_Reset_Spy_Bot.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/EMA21_5_crap.js
+++ b/Bots/risefall/EMA21_5_crap.js
@@ -1,0 +1,9 @@
+// JavaScript translation of EMA21-5-crap.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/HA.js
+++ b/Bots/risefall/HA.js
@@ -1,0 +1,9 @@
+// JavaScript translation of HA.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/MACDEMA.js
+++ b/Bots/risefall/MACDEMA.js
@@ -1,0 +1,9 @@
+// JavaScript translation of MACDEMA.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/MACD_BOLLINGER_Bands_NO_MARTIANGLE.js
+++ b/Bots/risefall/MACD_BOLLINGER_Bands_NO_MARTIANGLE.js
@@ -1,0 +1,9 @@
+// JavaScript translation of MACD_BOLLINGER_Bands (NO MARTIANGLE).xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/RF_TICK_PAUSE.js
+++ b/Bots/risefall/RF_TICK_PAUSE.js
@@ -1,0 +1,9 @@
+// JavaScript translation of RF-TICK-PAUSE.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/RSI_BOT_ACCURATING_BOT.js
+++ b/Bots/risefall/RSI_BOT_ACCURATING_BOT.js
@@ -1,0 +1,9 @@
+// JavaScript translation of RSI BOT ACCURATING BOT.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/RSI_MACD.js
+++ b/Bots/risefall/RSI_MACD.js
@@ -1,0 +1,9 @@
+// JavaScript translation of RSI&MACD.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/RSI_bot_with_TakeProfit_StopLoss_v3.js
+++ b/Bots/risefall/RSI_bot_with_TakeProfit_StopLoss_v3.js
@@ -1,0 +1,9 @@
+// JavaScript translation of RSI bot with TakeProfit StopLoss v3.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/R_F_Sideway_3_1_Bot.js
+++ b/Bots/risefall/R_F_Sideway_3_1_Bot.js
@@ -1,0 +1,9 @@
+// JavaScript translation of R_F Sideway 3.1 Bot.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Reverse_Martingale_with_upward_tick.js
+++ b/Bots/risefall/Reverse_Martingale_with_upward_tick.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Reverse-Martingale with upward tick.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Rise_Fall_Martingale.js
+++ b/Bots/risefall/Rise_Fall_Martingale.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Rise_Fall Martingale.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Rsi_safe_bot.js
+++ b/Bots/risefall/Rsi_safe_bot.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Rsi safe bot.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Rsi_safe_bot_1.js
+++ b/Bots/risefall/Rsi_safe_bot_1.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Rsi safe bot (1).xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/SMART_RISE_AND_FALL_BOT.js
+++ b/Bots/risefall/SMART_RISE_AND_FALL_BOT.js
@@ -1,0 +1,9 @@
+// JavaScript translation of SMART RISE AND FALL BOT.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/SMART_RISE_AND_FALL_BOT_1.js
+++ b/Bots/risefall/SMART_RISE_AND_FALL_BOT_1.js
@@ -1,0 +1,9 @@
+// JavaScript translation of SMART RISE AND FALL BOT(1).xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/SimpleEMA1.js
+++ b/Bots/risefall/SimpleEMA1.js
@@ -1,0 +1,9 @@
+// JavaScript translation of SimpleEMA1.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Step_stop_loss.js
+++ b/Bots/risefall/Step_stop_loss.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Step-stop-loss.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Tick_Power_Flow_Auto_Bot.js
+++ b/Bots/risefall/Tick_Power_Flow_Auto_Bot.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Tick_Power_Flow Auto-Bot.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Tick_Worm_RF_Versi_XML.js
+++ b/Bots/risefall/Tick_Worm_RF_Versi_XML.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Tick-Worm-RF-Versi_XML.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/Yen_Forex_DBot.js
+++ b/Bots/risefall/Yen_Forex_DBot.js
@@ -1,0 +1,9 @@
+// JavaScript translation of Yen-Forex_DBot.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/bestbot.js
+++ b/Bots/risefall/bestbot.js
@@ -1,0 +1,9 @@
+// JavaScript translation of bestbot.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/binary_bot_BOB_EMA_RF_v_3.js
+++ b/Bots/risefall/binary_bot_BOB_EMA_RF_v_3.js
@@ -1,0 +1,9 @@
+// JavaScript translation of binary-bot BOB EMA RF v.3.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/binary_bot_resetcall_tes_drive.js
+++ b/Bots/risefall/binary_bot_resetcall_tes_drive.js
@@ -1,0 +1,9 @@
+// JavaScript translation of binary-bot resetcall tes drive.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/binary_bot_up_down_5sv2.js
+++ b/Bots/risefall/binary_bot_up_down_5sv2.js
@@ -1,0 +1,9 @@
+// JavaScript translation of binary-bot up down 5sv2.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/bot_mascd_rsi.js
+++ b/Bots/risefall/bot_mascd_rsi.js
@@ -1,0 +1,9 @@
+// JavaScript translation of bot-mascd-rsi.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/saarsalu_greeeeeeeen_red_buy.js
+++ b/Bots/risefall/saarsalu_greeeeeeeen_red_buy.js
@@ -1,0 +1,9 @@
+// JavaScript translation of saarsalu greeeeeeeen red buy.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/safeprofitpro_2.js
+++ b/Bots/risefall/safeprofitpro_2.js
@@ -1,0 +1,9 @@
+// JavaScript translation of safeprofitpro 2.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/saferbot.js
+++ b/Bots/risefall/saferbot.js
@@ -1,0 +1,9 @@
+// JavaScript translation of saferbot.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/sup_res.js
+++ b/Bots/risefall/sup_res.js
@@ -1,0 +1,9 @@
+// JavaScript translation of sup - res.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };

--- a/Bots/risefall/teebot2_rev1.js
+++ b/Bots/risefall/teebot2_rev1.js
@@ -1,0 +1,9 @@
+// JavaScript translation of teebot2.rev1.xml
+// This is a placeholder stub for the bot logic.
+
+function init() {}
+function beforePurchase() {}
+function tickAnalysis() {}
+function afterPurchase(result) {}
+
+module.exports = { init, beforePurchase, tickAnalysis, afterPurchase };


### PR DESCRIPTION
## Summary
- convert 5_Best_Rsi_90_10_Profit_7%_diario bot from placeholder to RSI-based trading logic
- implement AT bot 1-3-7 martingale strategy
- implement BB slow bot Bollinger-band strategy

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba766a4248329aebb6c6d362055a3